### PR TITLE
Changed permissions for couch db directory

### DIFF
--- a/MVP/setup/couchExt.sh
+++ b/MVP/setup/couchExt.sh
@@ -57,6 +57,13 @@ cd $EXTRACT/$RELEASE-$VERSION || error_exit "Failure moving to "$EXTRACT/$RELEAS
 # Move to proper directory
 tar -xvzf couchdb.tar.gz
 sudo mv couchdb /home
+
+echo "Correcting permissions on couchdb directory"
+sudo chown -R couchdb:couchdb /home/couchdb
+
+echo "Adding pi user to couchdb group"
+sudo usermod -a -G couchdb pi
+
 echo $(date +"%D %T") "CouchDB moved"
 
 


### PR DESCRIPTION
After untaring the couchdb binary, the extracted folder has
the 'pi' user permissions. This commit changes those permissions
to couchdb owner and group to avoid permission errors on install.

I tested this out on a fresh install and it was able to make it past the previously seen couchdb errors.